### PR TITLE
Revision of STVAL and MTVAL assignment

### DIFF
--- a/ArchImpl/RISCV64/RISCV64Arch.cpp
+++ b/ArchImpl/RISCV64/RISCV64Arch.cpp
@@ -884,9 +884,6 @@ static InstructionDefinition lb_rd_imm_rs1_(
 		
 		"if(exception)\n"
 		"{\n"
-			// set stval and mtval in case of exception
-			"((RISCV64*)cpu)->CSR[0x143] = (etiss_int64)offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = (etiss_int64)offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 

--- a/ArchImpl/RISCV64/RISCV64Arch.cpp
+++ b/ArchImpl/RISCV64/RISCV64Arch.cpp
@@ -997,9 +997,6 @@ static InstructionDefinition sb_rs2_imm_rs1_(
 		
 		"if(exception)\n"
 		"{\n"
-			// set stval and mtval in case of exception
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -1424,9 +1421,6 @@ static InstructionDefinition lh_rd_imm_rs1_(
 		
 		"if(exception)\n"
 		"{\n"
-			// set stval and mtval in case of exception
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -1540,9 +1534,6 @@ static InstructionDefinition sh_rs2_imm_rs1_(
 		
 		"if(exception)\n"
 		"{\n"
-			// set stval and mtval in case of exception
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -1903,9 +1894,6 @@ static InstructionDefinition lbu_rd_imm_rs1_(
 		
 		"if(exception)\n"
 		"{\n"
-			// set stval and mtval in case of exception
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -2232,9 +2220,6 @@ static InstructionDefinition lhu_rd_imm_rs1_(
 		
 		"if(exception)\n"
 		"{\n"
-			// set stval and mtval in case of exception
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -2695,9 +2680,6 @@ static InstructionDefinition lwu_rd_imm_rs1_(
 		
 		"if(exception)\n"
 		"{\n"
-			// set stval and mtval in case of exception
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -3092,9 +3074,6 @@ static InstructionDefinition lw_rd_imm_rs1_(
 		
 		"if(exception)\n"
 		"{\n"
-			// set stval and mtval in case of exception
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -3208,9 +3187,6 @@ static InstructionDefinition sw_rs2_imm_rs1_(
 		
 		"if(exception)\n"
 		"{\n"
-			// set stval and mtval in case of exception
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -3524,8 +3500,6 @@ static InstructionDefinition flw_rd_imm_xrs1_(
 		// manually added
 		"if (exception)\n"
 		"{\n"
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -3640,8 +3614,6 @@ static InstructionDefinition fsw_rs2_imm_xrs1_(
 		// manually added
 		"if (exception)\n"
 		"{\n"
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -3942,9 +3914,6 @@ static InstructionDefinition ld_rd_imm_rs1_(
 		
 		"if(exception)\n"
 		"{\n"
-			// set stval and mtval in case of exception
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -4058,9 +4027,6 @@ static InstructionDefinition sd_rs2_imm_rs1_(
 		
 		"if(exception)\n"
 		"{\n"
-			// set stval and mtval in case of exception
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -4185,8 +4151,6 @@ static InstructionDefinition fld_rd_imm_rs1_(
 		// manually added
 		"if (exception)\n"
 		"{\n"
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -4301,8 +4265,6 @@ static InstructionDefinition fsd_rs2_imm_rs1_(
 		// manually added
 		"if (exception)\n"
 		"{\n"
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -15944,8 +15906,6 @@ static InstructionDefinition c_fld_rd_uimm_8_rs1_(
 		// manually added
 		"if (exception)\n"
 		"{\n"
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -16039,8 +15999,6 @@ static InstructionDefinition c_fldsp_rd_uimm_x2_(
 		// manually added
 		"if (exception)\n"
 		"{\n"
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -17384,8 +17342,6 @@ static InstructionDefinition c_fsd_rs2_uimm_8_rs1_(
 		// manually added
 		"if (exception)\n"
 		"{\n"
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 
@@ -17463,8 +17419,6 @@ static InstructionDefinition c_fsdsp_rs2_uimm_x2_(
 		// manually added
 		"if (exception)\n"
 		"{\n"
-			"((RISCV64*)cpu)->CSR[0x143] = offs;\n"
-			"((RISCV64*)cpu)->CSR[0x343] = offs;\n"
 			"return exception;\n"
 		"}\n"
 ; 

--- a/ArchImpl/RISCV64/RISCV64ArchSpecificImp.h
+++ b/ArchImpl/RISCV64/RISCV64ArchSpecificImp.h
@@ -129,7 +129,7 @@ etiss::int32 RISCV64Arch::handleException(etiss::int32 cause, ETISS_CPU *cpu)
                     case CAUSE_FETCH_ACCESS:
                         // Redo the instruction encoutered exception after handling
                         ((RISCV64 *)cpu)->CSR[CSR_SEPC] = cpu->instructionPointer;
-                        ((RISCV64 *)cpu)->CSR[CSR_STVAL] = cpu->instructionPointer;
+                        ((RISCV64 *)cpu)->CSR[CSR_MTVAL] = 0;
                         break;
                     case CAUSE_LOAD_PAGE_FAULT:     [[fallthrough]];
                     case CAUSE_LOAD_ACCESS:         [[fallthrough]];
@@ -145,6 +145,7 @@ etiss::int32 RISCV64Arch::handleException(etiss::int32 cause, ETISS_CPU *cpu)
                         // Redo the instruction encoutered exception after handling
                         ((RISCV64 *)cpu)->CSR[CSR_SEPC] = cpu->instructionPointer - 4;
                         ((RISCV64 *)cpu)->CSR[CSR_STVAL] = 0;
+                        ((RISCV64 *)cpu)->CSR[CSR_MTVAL] = 0;
                         break;
                 }
                 ((RISCV64 *)cpu)->CSR[CSR_SSTATUS] ^=
@@ -165,7 +166,7 @@ etiss::int32 RISCV64Arch::handleException(etiss::int32 cause, ETISS_CPU *cpu)
                     case CAUSE_MISALIGNED_FETCH:
                         // Redo the instruction encoutered exception after handling
                         ((RISCV64 *)cpu)->CSR[CSR_MEPC] = cpu->instructionPointer;
-                        ((RISCV64 *)cpu)->CSR[CSR_MTVAL] = cpu->instructionPointer;
+                        ((RISCV64 *)cpu)->CSR[CSR_STVAL] = 0;
                         break;
                     case CAUSE_LOAD_PAGE_FAULT:     [[fallthrough]];
                     case CAUSE_LOAD_ACCESS:         [[fallthrough]];
@@ -181,6 +182,7 @@ etiss::int32 RISCV64Arch::handleException(etiss::int32 cause, ETISS_CPU *cpu)
                         // Redo the instruction encoutered exception after handling
                         ((RISCV64 *)cpu)->CSR[CSR_MEPC] = cpu->instructionPointer - 4;
                         ((RISCV64 *)cpu)->CSR[CSR_MTVAL] = 0;
+                        ((RISCV64 *)cpu)->CSR[CSR_STVAL] = 0;
                         break;
                 }
                 (((RISCV64 *)cpu)->CSR[CSR_MSTATUS]) ^=

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -202,6 +202,8 @@ int32_t RISCV64MMU::WalkPageTable(uint64_t vma, MM_ACCESS access)
     return etiss::RETURNCODE::NOERROR;
 
 RETURN_PAGEFAULT:
+    ((RISCV64*)cpu_)->CSR[CSR_STVAL] = vma;
+    ((RISCV64*)cpu_)->CSR[CSR_MTVAL] = vma;
     switch (access)
     {
     case R_ACCESS:
@@ -267,3 +269,24 @@ int32_t RISCV64MMU::CheckProtection(const PTE &pte, MM_ACCESS access)
     }
     return etiss::RETURNCODE::NOERROR;
 }
+
+// int32_t RISCV64MMU::CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length)
+// {
+//     // Determine what page is used (ie. page, superpage, megapage)
+//     uint64_t page_size = PAGE_SIZE;
+//     uint64_t offset_mask = OFFSET_MASK;
+
+//     uint64_t next_page_vma = (vma + page_size) & !offset_mask;
+//     if (unlikely(next_page_vma == 0))
+//         return etiss::RETURNCODE::PAGEFAULT;
+//     int64_t overlap = vma - next_page_vma + length;
+//     uint32_t fault = etiss::RETURNCODE::NOERROR;
+
+//     // Check if vma + length overlaps page-boundary
+//     if (likely(overlap <= 0))
+//         return fault;
+
+//     // ensure next page is in memory
+//     fault = this->Translate(next_page_vma, pma_buf, access, overlap);
+//     return fault;
+// }


### PR DESCRIPTION
MTVAL and STVAL are now assigned in page-table-walker, after a page-fault was detected.
Thus all assignments of STVAL and MTVAL in the generated instruction code can be removed. 