### PR TITLE
Memory access over page boundary

### DIFF
--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -154,22 +154,6 @@ int32_t RISCV64MMU::WalkPageTable(uint64_t vma, MM_ACCESS access)
         {
         }
 
-        if (0 == leaf_pte.GetByName("A"))
-        {
-            leaf_pte_val |= PTE_A;
-            leaf_pte.Update(leaf_pte_val);
-            if ((fault = system_->dwrite(system_->handle, cpu_, addr, buffer, PTESIZE)))
-                return fault;
-        }
-
-        if ((0 == leaf_pte.GetByName("D")) && (W_ACCESS == access))
-        {
-            leaf_pte_val |= PTE_D;
-            leaf_pte.Update(leaf_pte_val);
-            if ((fault = system_->dwrite(system_->handle, cpu_, addr, buffer, PTESIZE)))
-                return fault;
-        }
-
         // TODO: PMA, PMP check should be implemented later on.
 
         uint64_t new_pte_val = leaf_pte.Get();
@@ -292,7 +276,7 @@ int32_t RISCV64MMU::UpdatePTEFlags(PTE &pte, etiss::mm::MM_ACCESS access)
         if ((fault = system_->dwrite(system_->handle, cpu_, pte_addr, buffer, PTESIZE)))
             return fault;
     }
-    
+
     return fault;
 }
 

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -277,7 +277,7 @@ int32_t RISCV64MMU::CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf
     uint64_t page_size = 1 << (PAGE_OFFSET + page_level * VPN_OFFSET);
     uint64_t offset_mask = page_size - 1;
 
-    uint64_t next_page_vma = vma & !offset_mask + page_size;
+    uint64_t next_page_vma = vma & ~offset_mask + page_size;
     int64_t overlap = vma - next_page_vma + length;
 
     // Check if vma + length overlaps page-boundary

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -130,7 +130,7 @@ int32_t RISCV64MMU::WalkPageTable(uint64_t vma, MM_ACCESS access)
             if ((fault = system_->dread(system_->handle, cpu_, addr, buffer, PTESIZE)))
                 return fault;
             // A new leaf pte value is read from page directory
-            leaf_pte.Update(leaf_pte_val, i);
+            leaf_pte.Update(leaf_pte_val);
 
             if ((0 == leaf_pte.GetByName("V")) || ((0 == leaf_pte.GetByName("R")) && (1 == leaf_pte.GetByName("W"))))
             {
@@ -193,7 +193,7 @@ int32_t RISCV64MMU::WalkPageTable(uint64_t vma, MM_ACCESS access)
                 new_pte_val |= vma_pte.GetByName(vpn_name.str()) << ((VPN_OFFSET * tmp_i) + 10);
             }
         }
-        PTE new_pte = PTE(new_pte_val);
+        PTE new_pte = PTE(new_pte_val, i);
         AddTLBEntry(vma >> PAGE_OFFSET, new_pte);
         // Map TLB entry to physical address for write-through, because TLB is more or less a cache
         AddTLBEntryMap(addr, new_pte);

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -270,23 +270,23 @@ int32_t RISCV64MMU::CheckProtection(const PTE &pte, MM_ACCESS access)
     return etiss::RETURNCODE::NOERROR;
 }
 
-// int32_t RISCV64MMU::CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length)
-// {
-//     // Determine what page is used (ie. page, superpage, megapage)
-//     uint64_t page_size = PAGE_SIZE;
-//     uint64_t offset_mask = OFFSET_MASK;
+int32_t RISCV64MMU::CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length)
+{
+    // Determine what page is used (ie. page, superpage, megapage)
+    uint64_t page_size = PAGE_SIZE;
+    uint64_t offset_mask = OFFSET_MASK;
 
-//     uint64_t next_page_vma = (vma + page_size) & !offset_mask;
-//     if (unlikely(next_page_vma == 0))
-//         return etiss::RETURNCODE::PAGEFAULT;
-//     int64_t overlap = vma - next_page_vma + length;
-//     uint32_t fault = etiss::RETURNCODE::NOERROR;
+    uint64_t next_page_vma = (vma + page_size) & !offset_mask;
+    if (unlikely(next_page_vma == 0))
+        return etiss::RETURNCODE::PAGEFAULT;
+    int64_t overlap = vma - next_page_vma + length;
+    uint32_t fault = etiss::RETURNCODE::NOERROR;
 
-//     // Check if vma + length overlaps page-boundary
-//     if (likely(overlap <= 0))
-//         return fault;
+    // Check if vma + length overlaps page-boundary
+    if (likely(overlap <= 0))
+        return fault;
 
-//     // ensure next page is in memory
-//     fault = this->Translate(next_page_vma, pma_buf, access, overlap);
-//     return fault;
-// }
+    // ensure next page is in memory
+    fault = this->Translate(next_page_vma, pma_buf, access, overlap);
+    return fault;
+}

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -279,7 +279,6 @@ int32_t RISCV64MMU::CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf
 
     uint64_t next_page_vma = (vma + page_size) & !offset_mask;
     int64_t overlap = vma - next_page_vma + length;
-    uint32_t fault = etiss::RETURNCODE::NOERROR;
 
     // Check if vma + length overlaps page-boundary
     if (likely(overlap <= 0))

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -275,9 +275,9 @@ int32_t RISCV64MMU::CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf
     // Determine what page level is used (ie. normal page, super-page, mega-page)
     uint32_t page_level = pte.GetLVL();
     uint64_t page_size = 1 << (PAGE_OFFSET + page_level * VPN_OFFSET);
-    uint64_t offset_mask = page_size - 1;
+    uint64_t offset_mask = ~(page_size - 1);
 
-    uint64_t next_page_vma = vma & ~offset_mask + page_size;
+    uint64_t next_page_vma = (vma & offset_mask) + page_size;
     int64_t overlap = vma - next_page_vma + length;
 
     // Check if vma + length overlaps page-boundary

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -277,7 +277,7 @@ int32_t RISCV64MMU::CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf
     uint64_t page_size = 1 << (PAGE_OFFSET + page_level * VPN_OFFSET);
     uint64_t offset_mask = page_size - 1;
 
-    uint64_t next_page_vma = (vma + page_size) & !offset_mask;
+    uint64_t next_page_vma = vma & !offset_mask + page_size;
     int64_t overlap = vma - next_page_vma + length;
 
     // Check if vma + length overlaps page-boundary

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -278,16 +278,15 @@ int32_t RISCV64MMU::CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf
     uint64_t offset_mask = page_size - 1;
 
     uint64_t next_page_vma = (vma + page_size) & !offset_mask;
-    if (unlikely(next_page_vma == 0))
-        return etiss::RETURNCODE::PAGEFAULT;
     int64_t overlap = vma - next_page_vma + length;
     uint32_t fault = etiss::RETURNCODE::NOERROR;
 
     // Check if vma + length overlaps page-boundary
     if (likely(overlap <= 0))
-        return fault;
+        return etiss::RETURNCODE::NOERROR;
 
     // ensure next page is in memory
-    fault = this->Translate(next_page_vma, pma_buf, access, overlap);
-    return fault;
+    if (unlikely(next_page_vma == 0))
+        return etiss::RETURNCODE::PAGEFAULT;    // this should be etiss::RETURNCODE::MISALIGNED!
+    return this->Translate(next_page_vma, pma_buf, access, overlap);
 }

--- a/ArchImpl/RISCV64/RISCV64MMU.h
+++ b/ArchImpl/RISCV64/RISCV64MMU.h
@@ -68,7 +68,7 @@ class RISCV64MMU : public etiss::mm::MMU
 
     int32_t CheckProtection(const PTE &pte, etiss::mm::MM_ACCESS access);
 
-    void UpdatePTEFlags(PTE &pte, etiss::mm::MM_ACCESS access) {}
+    int32_t UpdatePTEFlags(PTE &pte, etiss::mm::MM_ACCESS access);
 
     bool CheckPrivilegedMode() { return (((RISCV64 *)cpu_)->CSR[3088] == PRV_M) ? false : true; }
 

--- a/ArchImpl/RISCV64/RISCV64MMU.h
+++ b/ArchImpl/RISCV64/RISCV64MMU.h
@@ -71,6 +71,8 @@ class RISCV64MMU : public etiss::mm::MMU
     void UpdatePTEFlags(PTE &pte, etiss::mm::MM_ACCESS access) {}
 
     bool CheckPrivilegedMode() { return (((RISCV64 *)cpu_)->CSR[3088] == PRV_M) ? false : true; }
+
+    int32_t CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length);
 };
 
 #endif

--- a/ArchImpl/RISCV64/RISCV64MMU.h
+++ b/ArchImpl/RISCV64/RISCV64MMU.h
@@ -72,7 +72,7 @@ class RISCV64MMU : public etiss::mm::MMU
 
     bool CheckPrivilegedMode() { return (((RISCV64 *)cpu_)->CSR[3088] == PRV_M) ? false : true; }
 
-    int32_t CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length, const PTE &pte);
+    uint32_t GetPageOverlap(const uint64_t vma, etiss_uint32 length, const PTE &pte);
 };
 
 #endif

--- a/ArchImpl/RISCV64/RISCV64MMU.h
+++ b/ArchImpl/RISCV64/RISCV64MMU.h
@@ -72,7 +72,7 @@ class RISCV64MMU : public etiss::mm::MMU
 
     bool CheckPrivilegedMode() { return (((RISCV64 *)cpu_)->CSR[3088] == PRV_M) ? false : true; }
 
-    int32_t CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length);
+    int32_t CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length, const PTE &pte);
 };
 
 #endif

--- a/include/etiss/mm/MMU.h
+++ b/include/etiss/mm/MMU.h
@@ -95,7 +95,7 @@ class MMU
      *@see 	etiss::mm::PTEFormatBuilder and etiss::mm::PTEFormat
      *
      */
-    virtual int32_t Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length = 0, uint64_t data = 0);
+    virtual int32_t Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, uint32_t length = 0, uint32_t* overlap = 0);
 
     /**
      * @brief Whenever the MMU control register changes, the MMU has to be notified
@@ -180,13 +180,13 @@ class MMU
      * @brief Checks if memory access is overlapping page-boundary.
      *    This is architecture specific and should be implemented by architecture.
      * 
-     * @param vma 
-     * @param pma_buf 
-     * @param access 
-     * @param length 
-     * @return int32_t 
+     * @param vma virtual memory address of the current page
+     * @param length legth of the memory access
+     * @param pte page-table-element pointing to the current page
+     * @return uint32_t overlap. Where overlap is the amount of bytes, the access overlaps
+     *    into the next page. If there is no overlap, the funtion returns 0.
      */
-    virtual int32_t CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length, const PTE &pte) = 0;
+    virtual uint32_t GetPageOverlap(const uint64_t vma, etiss_uint32 length, const PTE &pte) = 0;
 
   protected:
     ETISS_CPU *cpu_;

--- a/include/etiss/mm/MMU.h
+++ b/include/etiss/mm/MMU.h
@@ -150,7 +150,7 @@ class MMU
      * @brief Reserved for some MMU that might update PTE when translating
      *
      */
-    virtual void UpdatePTEFlags(PTE &, MM_ACCESS) {}
+    virtual int32_t UpdatePTEFlags(PTE &, MM_ACCESS) {}
 
     bool IsTLBFull() const { return tlb_->IsFull(); }
 

--- a/include/etiss/mm/MMU.h
+++ b/include/etiss/mm/MMU.h
@@ -186,7 +186,7 @@ class MMU
      * @param length 
      * @return int32_t 
      */
-    virtual int32_t CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length) { return 0; }
+    virtual int32_t CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length, const PTE &pte) = 0;
 
   protected:
     ETISS_CPU *cpu_;

--- a/include/etiss/mm/MMU.h
+++ b/include/etiss/mm/MMU.h
@@ -95,7 +95,7 @@ class MMU
      *@see 	etiss::mm::PTEFormatBuilder and etiss::mm::PTEFormat
      *
      */
-    virtual int32_t Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, uint32_t length = 0, uint32_t* overlap = 0);
+    virtual int32_t Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, uint32_t* overlap, uint32_t length = 0);
 
     /**
      * @brief Whenever the MMU control register changes, the MMU has to be notified

--- a/include/etiss/mm/MMU.h
+++ b/include/etiss/mm/MMU.h
@@ -150,7 +150,7 @@ class MMU
      * @brief Reserved for some MMU that might update PTE when translating
      *
      */
-    virtual int32_t UpdatePTEFlags(PTE &, MM_ACCESS) {}
+    virtual int32_t UpdatePTEFlags(PTE &, MM_ACCESS) = 0;
 
     bool IsTLBFull() const { return tlb_->IsFull(); }
 

--- a/include/etiss/mm/MMU.h
+++ b/include/etiss/mm/MMU.h
@@ -186,7 +186,7 @@ class MMU
      * @param length 
      * @return int32_t 
      */
-    virtual int32_t CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length) { return etiss::RETURNCODE::NOERROR; }
+    virtual int32_t CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length) { return 0; }
 
   protected:
     ETISS_CPU *cpu_;

--- a/include/etiss/mm/MMU.h
+++ b/include/etiss/mm/MMU.h
@@ -95,7 +95,7 @@ class MMU
      *@see 	etiss::mm::PTEFormatBuilder and etiss::mm::PTEFormat
      *
      */
-    virtual int32_t Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, uint64_t data = 0);
+    virtual int32_t Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length = 0, uint64_t data = 0);
 
     /**
      * @brief Whenever the MMU control register changes, the MMU has to be notified
@@ -175,6 +175,18 @@ class MMU
     virtual int32_t GetPid(uint64_t control_reg_val_) { return 0; }
 
     std::shared_ptr<etiss::mm::TLB<0>> GetTLB() { return tlb_; }
+
+    /**
+     * @brief Checks if memory access is overlapping page-boundary.
+     *    This is architecture specific and should be implemented by architecture.
+     * 
+     * @param vma 
+     * @param pma_buf 
+     * @param access 
+     * @param length 
+     * @return int32_t 
+     */
+    virtual int32_t CheckPageOverlap(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length) { return etiss::RETURNCODE::NOERROR; }
 
   protected:
     ETISS_CPU *cpu_;

--- a/include/etiss/mm/PTE.h
+++ b/include/etiss/mm/PTE.h
@@ -70,7 +70,7 @@ class PTE
   public:
     PTE(){};
 
-    PTE(uint64_t pte) { Update(pte); }
+    PTE(uint64_t pte) { Update(pte, 0); }
 
     // PTE(const PTE & pte_cp_){
     // 	Update(pte_cp_.pte_val_);
@@ -88,7 +88,14 @@ class PTE
      * @brief Update the PTE with a new value.
      *
      */
-    void Update(uint64_t new_pte, uint32_t level = 0);
+    void Update(uint64_t new_pte);
+
+    /**
+     * @brief Update the PTE with a new value
+     *    and a page table level.
+     *
+     */
+    void Update(uint64_t new_pte, uint32_t level);
 
     /**
      * @brief Get the bit field value with its name

--- a/include/etiss/mm/PTE.h
+++ b/include/etiss/mm/PTE.h
@@ -70,9 +70,9 @@ class PTE
   public:
     PTE(){};
 
-    PTE(uint64_t pte) { Update(pte, 0); }
+    PTE(uint64_t pte) { Update(pte, 0, 0); }
 
-    PTE(uint64_t pte, uint32_t level) { Update(pte, level); }
+    PTE(uint64_t pte, uint32_t level, uint64_t phy_addr) { Update(pte, level, phy_addr); }
 
     // PTE(const PTE & pte_cp_){
     // 	Update(pte_cp_.pte_val_);
@@ -97,7 +97,7 @@ class PTE
      *    and a page table level.
      *
      */
-    void Update(uint64_t new_pte, uint32_t level);
+    void Update(uint64_t new_pte, uint32_t level, uint64_t phy_addr);
 
     /**
      * @brief Get the bit field value with its name
@@ -129,6 +129,8 @@ class PTE
 
     uint32_t GetLVL() const { return pte_lvl_; }
 
+    uint64_t GetAddr() const { return pte_addr_; }
+
   private:
     uint64_t GenerateMask(uint64_t len) const
     {
@@ -149,6 +151,7 @@ class PTE
     uint64_t ppn_val_;
     uint64_t pte_val_;
     uint32_t pte_lvl_;
+    uint64_t pte_addr_;
 };
 
 } // namespace mm

--- a/include/etiss/mm/PTE.h
+++ b/include/etiss/mm/PTE.h
@@ -72,6 +72,8 @@ class PTE
 
     PTE(uint64_t pte) { Update(pte, 0); }
 
+    PTE(uint64_t pte, uint32_t level) { Update(pte, level); }
+
     // PTE(const PTE & pte_cp_){
     // 	Update(pte_cp_.pte_val_);
 

--- a/include/etiss/mm/PTE.h
+++ b/include/etiss/mm/PTE.h
@@ -88,7 +88,7 @@ class PTE
      * @brief Update the PTE with a new value.
      *
      */
-    void Update(uint64_t new_pte);
+    void Update(uint64_t new_pte, uint32_t level = 0);
 
     /**
      * @brief Get the bit field value with its name
@@ -118,6 +118,8 @@ class PTE
 
     uint64_t GetPPN() const { return ppn_val_; }
 
+    uint32_t GetLVL() const { return pte_lvl_; }
+
   private:
     uint64_t GenerateMask(uint64_t len) const
     {
@@ -137,6 +139,7 @@ class PTE
 
     uint64_t ppn_val_;
     uint64_t pte_val_;
+    uint32_t pte_lvl_;
 };
 
 } // namespace mm

--- a/src/Translation.cpp
+++ b/src/Translation.cpp
@@ -496,7 +496,7 @@ etiss::int32 Translation::translateBlock(CodeBlock &cb)
             }
             else
             {
-                break; // non empty block -> compile pending // even if we got a pagefault??
+                break; // non empty block -> compile pending
             }
         }
 

--- a/src/mm/DMMUWrapper.cpp
+++ b/src/mm/DMMUWrapper.cpp
@@ -140,7 +140,7 @@ static etiss_int32 dbg_read(void *handle, etiss_uint64 addr, etiss_uint8 *buffer
     if (unlikely((exception = mmu->Translate(addr, &pma, MM_ACCESS::X_ACCESS, 4)) != etiss::RETURNCODE::NOERROR))   // !hot-fix: length should not be constant
         return exception;
     ETISS_System *sys = msys->orig;
-    return sys->dbg_read(sys->handle, pma, buffer, length);
+    return sys->dbg_read(sys->handle, pma, buffer, 4);  // !hot-fix: length should not be constant
 }
 
 static etiss_int32 dbg_write(void *handle, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)

--- a/src/mm/DMMUWrapper.cpp
+++ b/src/mm/DMMUWrapper.cpp
@@ -65,7 +65,7 @@ static etiss_int32 iread(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::R_ACCESS)))
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::R_ACCESS, length)))
         return exception;
     std::stringstream msg;
     msg << "Virtual memory: 0x" << std::hex << addr << " is translated into physical address 0x:" << std::hex << pma
@@ -84,7 +84,7 @@ static etiss_int32 iwrite(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS)))
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, length)))
         return exception;
     std::stringstream msg;
     msg << "Virtual memory: 0x" << std::hex << addr << " is translated into physical address 0x:" << std::hex << pma
@@ -103,7 +103,7 @@ static etiss_int32 dread(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::R_ACCESS)))
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::R_ACCESS, length)))
         return exception;
     std::stringstream msg;
 
@@ -120,7 +120,7 @@ static etiss_int32 dwrite(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS)))
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, length)))
         return exception;
     std::stringstream msg;
 
@@ -137,7 +137,7 @@ static etiss_int32 dbg_read(void *handle, etiss_uint64 addr, etiss_uint8 *buffer
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely((exception = mmu->Translate(addr, &pma, MM_ACCESS::X_ACCESS)) != etiss::RETURNCODE::NOERROR))
+    if (unlikely((exception = mmu->Translate(addr, &pma, MM_ACCESS::X_ACCESS, length)) != etiss::RETURNCODE::NOERROR))
         return exception;
     ETISS_System *sys = msys->orig;
     return sys->dbg_read(sys->handle, pma, buffer, length);
@@ -152,7 +152,7 @@ static etiss_int32 dbg_write(void *handle, etiss_uint64 addr, etiss_uint8 *buffe
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS)))
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, length)))
         return exception;
     std::stringstream msg;
     msg << "Virtual memory: 0x" << std::hex << addr << " is translated into physical address 0x:" << std::hex << pma

--- a/src/mm/DMMUWrapper.cpp
+++ b/src/mm/DMMUWrapper.cpp
@@ -141,7 +141,7 @@ static etiss_int32 dbg_read(void *handle, etiss_uint64 addr, etiss_uint8 *buffer
 
     // vma to pma translation
     uint64_t pma = 0;
-    uint32_t overlap;
+    uint32_t overlap = 0;
     if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::X_ACCESS, &overlap, length)))
         return exception;
     

--- a/src/mm/DMMUWrapper.cpp
+++ b/src/mm/DMMUWrapper.cpp
@@ -72,6 +72,23 @@ static etiss_int32 iread(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_
     msg << "Virtual memory: 0x" << std::hex << addr << " is translated into physical address 0x:" << std::hex << pma
         << std::endl;
     etiss::log(etiss::VERBOSE, msg.str());
+
+    // check for overlap
+    if (unlikely(overlap))
+    {
+        length -= overlap;
+        uint64_t vma_2 = addr + length;
+        uint64_t pma_2 = 0;
+        uint32_t tmp;
+        if (unlikely(exception = mmu->Translate(vma_2, &pma_2, MM_ACCESS::X_ACCESS, &tmp)))
+            return exception;
+        
+        ETISS_System *sys = msys->orig;
+        if (unlikely(exception = sys->iread(sys->handle, cpu, pma, length)))
+            return exception;
+        return sys->iread(sys->handle, cpu, pma_2, overlap);
+    }
+
     ETISS_System *sys = msys->orig;
     return sys->iread(sys->handle, cpu, pma, length);
 }
@@ -92,6 +109,23 @@ static etiss_int32 iwrite(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss
     msg << "Virtual memory: 0x" << std::hex << addr << " is translated into physical address 0x:" << std::hex << pma
         << std::endl;
     etiss::log(etiss::VERBOSE, msg.str());
+
+    // check for overlap
+    if (unlikely(overlap))
+    {
+        length -= overlap;
+        uint64_t vma_2 = addr + length;
+        uint64_t pma_2 = 0;
+        uint32_t tmp;
+        if (unlikely(exception = mmu->Translate(vma_2, &pma_2, MM_ACCESS::X_ACCESS, &tmp)))
+            return exception;
+        
+        ETISS_System *sys = msys->orig;
+        if (unlikely(exception = sys->iwrite(sys->handle, cpu, pma, buffer, length)))
+            return exception;
+        return sys->iwrite(sys->handle, cpu, pma_2, buffer + length, overlap);
+    }
+
     ETISS_System *sys = msys->orig;
     return sys->iwrite(sys->handle, cpu, pma, buffer, length);
 }
@@ -108,7 +142,22 @@ static etiss_int32 dread(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_
     uint32_t overlap = 0;
     if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::R_ACCESS, &overlap, length)))
         return exception;
-    std::stringstream msg;
+
+    // check for overlap
+    if (unlikely(overlap))
+    {
+        length -= overlap;
+        uint64_t vma_2 = addr + length;
+        uint64_t pma_2 = 0;
+        uint32_t tmp;
+        if (unlikely(exception = mmu->Translate(vma_2, &pma_2, MM_ACCESS::X_ACCESS, &tmp)))
+            return exception;
+        
+        ETISS_System *sys = msys->orig;
+        if (unlikely(exception = sys->dread(sys->handle, cpu, pma, buffer, length)))
+            return exception;
+        return sys->dread(sys->handle, cpu, pma_2, buffer + length, overlap);
+    }
 
     ETISS_System *sys = msys->orig;
     return sys->dread(sys->handle, cpu, pma, buffer, length);
@@ -126,7 +175,22 @@ static etiss_int32 dwrite(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss
     uint32_t overlap = 0;
     if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, &overlap, length)))
         return exception;
-    std::stringstream msg;
+
+    // check for overlap
+    if (unlikely(overlap))
+    {
+        length -= overlap;
+        uint64_t vma_2 = addr + length;
+        uint64_t pma_2 = 0;
+        uint32_t tmp;
+        if (unlikely(exception = mmu->Translate(vma_2, &pma_2, MM_ACCESS::X_ACCESS, &tmp)))
+            return exception;
+        
+        ETISS_System *sys = msys->orig;
+        if (unlikely(exception = sys->dwrite(sys->handle, cpu, pma, buffer, length)))
+            return exception;
+        return sys->dwrite(sys->handle, cpu, pma_2, buffer + length, overlap);
+    }
 
     ETISS_System *sys = msys->orig;
     return sys->dwrite(sys->handle, cpu, pma, buffer, length);
@@ -181,6 +245,23 @@ static etiss_int32 dbg_write(void *handle, etiss_uint64 addr, etiss_uint8 *buffe
     msg << "Virtual memory: 0x" << std::hex << addr << " is translated into physical address 0x:" << std::hex << pma
         << std::endl;
     etiss::log(etiss::VERBOSE, msg.str());
+
+    // check for overlap
+    if (unlikely(overlap))
+    {
+        length -= overlap;
+        uint64_t vma_2 = addr + length;
+        uint64_t pma_2 = 0;
+        uint32_t tmp;
+        if (unlikely(exception = mmu->Translate(vma_2, &pma_2, MM_ACCESS::X_ACCESS, &tmp)))
+            return exception;
+        
+        ETISS_System *sys = msys->orig;
+        if (unlikely(exception = sys->dbg_write(sys->handle, pma, buffer, length)))
+            return exception;
+        return sys->dbg_write(sys->handle, pma_2, buffer + length, overlap);
+    }
+
     ETISS_System *sys = msys->orig;
     return sys->dbg_write(sys->handle, pma, buffer, length);
 }

--- a/src/mm/DMMUWrapper.cpp
+++ b/src/mm/DMMUWrapper.cpp
@@ -137,7 +137,7 @@ static etiss_int32 dbg_read(void *handle, etiss_uint64 addr, etiss_uint8 *buffer
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely((exception = mmu->Translate(addr, &pma, MM_ACCESS::X_ACCESS, length)) != etiss::RETURNCODE::NOERROR))
+    if (unlikely((exception = mmu->Translate(addr, &pma, MM_ACCESS::X_ACCESS, 4)) != etiss::RETURNCODE::NOERROR))   // !hot-fix: length should not be constant
         return exception;
     ETISS_System *sys = msys->orig;
     return sys->dbg_read(sys->handle, pma, buffer, length);
@@ -152,7 +152,7 @@ static etiss_int32 dbg_write(void *handle, etiss_uint64 addr, etiss_uint8 *buffe
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, length)))
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, 4)))   // !hot-fix: length should not be constant
         return exception;
     std::stringstream msg;
     msg << "Virtual memory: 0x" << std::hex << addr << " is translated into physical address 0x:" << std::hex << pma

--- a/src/mm/DMMUWrapper.cpp
+++ b/src/mm/DMMUWrapper.cpp
@@ -137,10 +137,10 @@ static etiss_int32 dbg_read(void *handle, etiss_uint64 addr, etiss_uint8 *buffer
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely((exception = mmu->Translate(addr, &pma, MM_ACCESS::X_ACCESS, 4)) != etiss::RETURNCODE::NOERROR))   // !hot-fix: length should not be constant
+    if (unlikely((exception = mmu->Translate(addr, &pma, MM_ACCESS::X_ACCESS, length)) != etiss::RETURNCODE::NOERROR))
         return exception;
     ETISS_System *sys = msys->orig;
-    return sys->dbg_read(sys->handle, pma, buffer, 4);  // !hot-fix: length should not be constant
+    return sys->dbg_read(sys->handle, pma, buffer, length);
 }
 
 static etiss_int32 dbg_write(void *handle, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
@@ -152,7 +152,7 @@ static etiss_int32 dbg_write(void *handle, etiss_uint64 addr, etiss_uint8 *buffe
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, 4)))   // !hot-fix: length should not be constant
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, length)))
         return exception;
     std::stringstream msg;
     msg << "Virtual memory: 0x" << std::hex << addr << " is translated into physical address 0x:" << std::hex << pma

--- a/src/mm/DMMUWrapper.cpp
+++ b/src/mm/DMMUWrapper.cpp
@@ -65,7 +65,8 @@ static etiss_int32 iread(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::R_ACCESS, length)))
+    uint32_t overlap = 0;
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::R_ACCESS, &overlap, length)))
         return exception;
     std::stringstream msg;
     msg << "Virtual memory: 0x" << std::hex << addr << " is translated into physical address 0x:" << std::hex << pma
@@ -84,7 +85,8 @@ static etiss_int32 iwrite(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, length)))
+    uint32_t overlap = 0;
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, &overlap, length)))
         return exception;
     std::stringstream msg;
     msg << "Virtual memory: 0x" << std::hex << addr << " is translated into physical address 0x:" << std::hex << pma
@@ -103,7 +105,8 @@ static etiss_int32 dread(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::R_ACCESS, length)))
+    uint32_t overlap = 0;
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::R_ACCESS, &overlap, length)))
         return exception;
     std::stringstream msg;
 
@@ -120,7 +123,8 @@ static etiss_int32 dwrite(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, length)))
+    uint32_t overlap = 0;
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, &overlap, length)))
         return exception;
     std::stringstream msg;
 
@@ -137,8 +141,8 @@ static etiss_int32 dbg_read(void *handle, etiss_uint64 addr, etiss_uint8 *buffer
 
     // vma to pma translation
     uint64_t pma = 0;
-    uint32_t overlap = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::X_ACCESS, length, &overlap)))
+    uint32_t overlap;
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::X_ACCESS, &overlap, length)))
         return exception;
     
     // check for overlap
@@ -147,7 +151,8 @@ static etiss_int32 dbg_read(void *handle, etiss_uint64 addr, etiss_uint8 *buffer
         length -= overlap;
         uint64_t vma_2 = addr + length;
         uint64_t pma_2 = 0;
-        if (unlikely(exception = mmu->Translate(vma_2, &pma_2, MM_ACCESS::X_ACCESS)))
+        uint32_t tmp;
+        if (unlikely(exception = mmu->Translate(vma_2, &pma_2, MM_ACCESS::X_ACCESS, &tmp)))
             return exception;
         
         ETISS_System *sys = msys->orig;
@@ -169,7 +174,8 @@ static etiss_int32 dbg_write(void *handle, etiss_uint64 addr, etiss_uint8 *buffe
 
     // vma to pma translation
     uint64_t pma = 0;
-    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, length)))
+    uint32_t overlap = 0;
+    if (unlikely(exception = mmu->Translate(addr, &pma, MM_ACCESS::W_ACCESS, &overlap, length)))
         return exception;
     std::stringstream msg;
     msg << "Virtual memory: 0x" << std::hex << addr << " is translated into physical address 0x:" << std::hex << pma

--- a/src/mm/MMU.cpp
+++ b/src/mm/MMU.cpp
@@ -135,7 +135,7 @@ int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS ac
         return fault;
     
     // Check if access to memory is overlapping a page-boundary
-    if ((fault = CheckPageOverlap(vma, pma_buf, access, length)))
+    if ((fault = CheckPageOverlap(vma, pma_buf, access, length, pte_buf)))
         return fault;
 
     uint64_t offset_mask = (1 << (page_offset_msb_pos + 1)) - 1;

--- a/src/mm/MMU.cpp
+++ b/src/mm/MMU.cpp
@@ -79,7 +79,7 @@ MMU::MMU(bool hw_ptw, std::string name, bool pid_enabled)
     // REGISTER_PAGE_FAULT_HANDLER(TLBISFULL, tlb_full_handler);
 }
 
-int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length, uint64_t data)
+int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, uint32_t length, uint32_t* overlap)
 {
 
     if (!mmu_enabled_)
@@ -135,8 +135,7 @@ int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS ac
         return fault;
     
     // Check if access to memory is overlapping a page-boundary
-    if ((fault = CheckPageOverlap(vma, pma_buf, access, length, pte_buf)))
-        return fault;
+    *overlap = GetPageOverlap(vma, length, pte_buf);
 
     uint64_t offset_mask = (1 << (page_offset_msb_pos + 1)) - 1;
     *pma_buf = (pte_buf.GetPPN() << (page_offset_msb_pos + 1)) | (vma & offset_mask);

--- a/src/mm/MMU.cpp
+++ b/src/mm/MMU.cpp
@@ -79,7 +79,7 @@ MMU::MMU(bool hw_ptw, std::string name, bool pid_enabled)
     // REGISTER_PAGE_FAULT_HANDLER(TLBISFULL, tlb_full_handler);
 }
 
-int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, uint64_t data)
+int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, etiss_uint32 length, uint64_t data)
 {
 
     if (!mmu_enabled_)
@@ -130,6 +130,10 @@ int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS ac
             etiss::log(etiss::FATALERROR, "TLB MISS is not correctly handled");
         }
     }
+
+    // Check if access to memory is overlapping a page-boundary
+    if ((fault = CheckPageOverlap(vma, pma_buf, access, length)))
+        return fault;
 
     if ((fault = CheckProtection(pte_buf, access)))
         return fault;

--- a/src/mm/MMU.cpp
+++ b/src/mm/MMU.cpp
@@ -79,7 +79,7 @@ MMU::MMU(bool hw_ptw, std::string name, bool pid_enabled)
     // REGISTER_PAGE_FAULT_HANDLER(TLBISFULL, tlb_full_handler);
 }
 
-int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, uint32_t length, uint32_t* overlap)
+int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS access, uint32_t* overlap, uint32_t length)
 {
 
     if (!mmu_enabled_)

--- a/src/mm/MMU.cpp
+++ b/src/mm/MMU.cpp
@@ -131,11 +131,11 @@ int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS ac
         }
     }
 
+    if ((fault = CheckProtection(pte_buf, access)))
+        return fault;
+    
     // Check if access to memory is overlapping a page-boundary
     if ((fault = CheckPageOverlap(vma, pma_buf, access, length)))
-        return fault;
-
-    if ((fault = CheckProtection(pte_buf, access)))
         return fault;
 
     uint64_t offset_mask = (1 << (page_offset_msb_pos + 1)) - 1;

--- a/src/mm/MMU.cpp
+++ b/src/mm/MMU.cpp
@@ -141,7 +141,8 @@ int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS ac
     uint64_t offset_mask = (1 << (page_offset_msb_pos + 1)) - 1;
     *pma_buf = (pte_buf.GetPPN() << (page_offset_msb_pos + 1)) | (vma & offset_mask);
 
-    UpdatePTEFlags(pte_buf, access);
+    if ((fault = UpdatePTEFlags(pte_buf, access)))
+        return fault;
 
     // Check whether vma is trying to write the data cached in TLB, if so
     // evict the PTE entry in the TLB

--- a/src/mm/PTE.cpp
+++ b/src/mm/PTE.cpp
@@ -59,6 +59,30 @@ namespace etiss
 namespace mm
 {
 
+void PTE::Update(uint64_t new_pte)
+{
+
+    if (PTEFormat::Instance().GetFormatMap().find(std::string("PPN")) == PTEFormat::Instance().GetFormatMap().end())
+    {
+        PTEFormat::Instance().Dump();
+        PTEFormat::Instance().Dump();
+        etiss::log(etiss::FATALERROR, "PPN not defined in PTE format");
+    }
+
+    std::pair<uint32_t, uint32_t> bit_field = PTEFormat::Instance().GetFormatMap().find(std::string("PPN"))->second;
+    if (new_pte & (~GenerateMask(PTEFormat::Instance().GetPTELength())))
+    {
+        std::stringstream msg;
+        msg << "PTE value: [0x" << std::hex << new_pte << "] exceed the format length " << std::dec
+            << PTEFormat::Instance().GetPTELength() << "." << std::endl;
+        PTEFormat::Instance().Dump();
+        etiss::log(etiss::FATALERROR, msg.str());
+    }
+
+    ppn_val_ = new_pte >> bit_field.second;
+    pte_val_ = new_pte;
+}
+
 void PTE::Update(uint64_t new_pte, uint32_t level)
 {
 

--- a/src/mm/PTE.cpp
+++ b/src/mm/PTE.cpp
@@ -83,7 +83,7 @@ void PTE::Update(uint64_t new_pte)
     pte_val_ = new_pte;
 }
 
-void PTE::Update(uint64_t new_pte, uint32_t level)
+void PTE::Update(uint64_t new_pte, uint32_t level, uint64_t phy_addr)
 {
 
     if (PTEFormat::Instance().GetFormatMap().find(std::string("PPN")) == PTEFormat::Instance().GetFormatMap().end())
@@ -106,6 +106,7 @@ void PTE::Update(uint64_t new_pte, uint32_t level)
     ppn_val_ = new_pte >> bit_field.second;
     pte_val_ = new_pte;
     pte_lvl_ = level;
+    pte_addr_ = phy_addr;
 }
 
 uint64_t PTE::GetByName(std::string const name) const

--- a/src/mm/PTE.cpp
+++ b/src/mm/PTE.cpp
@@ -59,7 +59,7 @@ namespace etiss
 namespace mm
 {
 
-void PTE::Update(uint64_t new_pte)
+void PTE::Update(uint64_t new_pte, uint32_t level)
 {
 
     if (PTEFormat::Instance().GetFormatMap().find(std::string("PPN")) == PTEFormat::Instance().GetFormatMap().end())
@@ -80,8 +80,8 @@ void PTE::Update(uint64_t new_pte)
     }
 
     ppn_val_ = new_pte >> bit_field.second;
-    ;
     pte_val_ = new_pte;
+    pte_lvl_ = level;
 }
 
 uint64_t PTE::GetByName(std::string const name) const


### PR DESCRIPTION
Implementing a way to access memory over a page boundary.
DMMUWrapper splits a memory access that overlaps a page in two accesses.
Address translations have to be performed for both accesses.