### PR TITLE
Rework of PTE-updates and SFENCE.VMA

### DIFF
--- a/ArchImpl/RISCV64/RISCV64.h
+++ b/ArchImpl/RISCV64/RISCV64.h
@@ -88,6 +88,7 @@ typedef struct RISCV64 RISCV64; // convenient use of X instead of struct X in ge
 // manually added
 extern int32_t ETISS_SIGNAL_MMU(ETISS_CPU *cpu, ETISS_System * const system, void * const * const plugin_pointers, etiss_uint64 mmu_signal_);
 extern int32_t ETISS_TLB_FLUSH(ETISS_CPU *cpu, ETISS_System * const system, void * const * const plugin_pointers);
+extern int32_t ETISS_TLB_EVICT_VMA(ETISS_CPU *cpu, ETISS_System * const system, void * const * const plugin_pointers, etiss_uint64 vma_);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/ArchImpl/RISCV64/RISCV64Arch.cpp
+++ b/ArchImpl/RISCV64/RISCV64Arch.cpp
@@ -7418,11 +7418,24 @@ rs2 += R_rs2_0.read(ba) << 0;
 
 // -----------------------------------------------------------------------------
 partInit.code() += "cpu->instructionPointer = " + std::to_string(ic.current_address_ + 4UL) + ";\n";
+partInit.code() += "etiss_int32 ret = 0U;\n";
 partInit.code() += "((RISCV64*)cpu)->FENCE[" + std::to_string(2U) + "] = " + std::to_string(rs1) + ";\n";
 partInit.code() += "((RISCV64*)cpu)->FENCE[" + std::to_string(3U) + "] = " + std::to_string(rs2) + ";\n";
 partInit.code() += "etiss_uint64 vaddr = *((RISCV64*)cpu)->X[" + std::to_string(rs1) + "];\n";
 partInit.code() += "etiss_uint64 asid = *((RISCV64*)cpu)->X[" + std::to_string(rs2) + "];\n";
-partInit.code() += "etiss_int32 ret = flush_tlb(cpu, system, plugin_pointers, vaddr, asid);\n";
+if (rs1 == 0U) {
+if (rs2 == 0U) {
+partInit.code() += "ret = evict_all(cpu, system, plugin_pointers);\n";
+} else {
+partInit.code() += "ret = evict_asid(cpu, system, plugin_pointers, asid);\n";
+}
+} else {
+if (rs2 == 0U) {
+partInit.code() += "ret = evict_addr(cpu, system, plugin_pointers, vaddr);\n";
+} else {
+partInit.code() += "ret = evict_addr_asid(cpu, system, plugin_pointers, vaddr, asid);\n";
+}
+}
 partInit.code() += "return ret;\n"; // manually added
 // -----------------------------------------------------------------------------
 

--- a/ArchImpl/RISCV64/RISCV64Funcs.h
+++ b/ArchImpl/RISCV64/RISCV64Funcs.h
@@ -57,7 +57,34 @@ etiss_int32 tmp = ETISS_SIGNAL_MMU(cpu, system, plugin_pointers, val);
 
 #ifndef ETISS_ARCH_STATIC_FN_ONLY
 
-static inline etiss_int32 flush_tlb (ETISS_CPU * const cpu, ETISS_System * const system, void * const * const plugin_pointers, etiss_uint64 vaddr, etiss_uint64 asid)
+static inline etiss_int32 evict_all (ETISS_CPU * const cpu, ETISS_System * const system, void * const * const plugin_pointers)
+{
+return ETISS_TLB_FLUSH(cpu, system, plugin_pointers);
+}
+
+#endif
+
+#ifndef ETISS_ARCH_STATIC_FN_ONLY
+
+static inline etiss_int32 evict_asid (ETISS_CPU * const cpu, ETISS_System * const system, void * const * const plugin_pointers, etiss_uint64 asid)
+{
+return ETISS_TLB_FLUSH(cpu, system, plugin_pointers);
+}
+
+#endif
+
+#ifndef ETISS_ARCH_STATIC_FN_ONLY
+
+static inline etiss_int32 evict_addr (ETISS_CPU * const cpu, ETISS_System * const system, void * const * const plugin_pointers, etiss_uint64 vaddr)
+{
+return ETISS_TLB_EVICT_VMA(cpu, system, plugin_pointers, vaddr);
+}
+
+#endif
+
+#ifndef ETISS_ARCH_STATIC_FN_ONLY
+
+static inline etiss_int32 evict_addr_asid (ETISS_CPU * const cpu, ETISS_System * const system, void * const * const plugin_pointers, etiss_uint64 vaddr, etiss_uint64 asid)
 {
 return ETISS_TLB_FLUSH(cpu, system, plugin_pointers);
 }

--- a/ArchImpl/RISCV64/RISCV64Funcs.h
+++ b/ArchImpl/RISCV64/RISCV64Funcs.h
@@ -77,7 +77,8 @@ return ETISS_TLB_FLUSH(cpu, system, plugin_pointers);
 
 static inline etiss_int32 evict_addr (ETISS_CPU * const cpu, ETISS_System * const system, void * const * const plugin_pointers, etiss_uint64 vaddr)
 {
-return ETISS_TLB_EVICT_VMA(cpu, system, plugin_pointers, vaddr);
+// return ETISS_TLB_EVICT_VMA(cpu, system, plugin_pointers, vaddr);
+return ETISS_TLB_FLUSH(cpu, system, plugin_pointers);
 }
 
 #endif

--- a/ArchImpl/RISCV64/RISCV64Funcs.h
+++ b/ArchImpl/RISCV64/RISCV64Funcs.h
@@ -77,8 +77,7 @@ return ETISS_TLB_FLUSH(cpu, system, plugin_pointers);
 
 static inline etiss_int32 evict_addr (ETISS_CPU * const cpu, ETISS_System * const system, void * const * const plugin_pointers, etiss_uint64 vaddr)
 {
-// return ETISS_TLB_EVICT_VMA(cpu, system, plugin_pointers, vaddr);
-return ETISS_TLB_FLUSH(cpu, system, plugin_pointers);
+return ETISS_TLB_EVICT_VMA(cpu, system, plugin_pointers, vaddr);
 }
 
 #endif

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -264,6 +264,7 @@ int32_t RISCV64MMU::UpdatePTEFlags(const uint64_t vfn, PTE *pte, etiss::mm::MM_A
     if (0 == pte->GetByName("A"))
     {
         pte_val |= PTE_A;
+        fault = tlb_->UpdatePTE(vfn, pte_val);
         if ((fault = system_->dwrite(system_->handle, cpu_, pte_addr, buffer, PTESIZE)))
             return fault;
     }
@@ -271,11 +272,11 @@ int32_t RISCV64MMU::UpdatePTEFlags(const uint64_t vfn, PTE *pte, etiss::mm::MM_A
     if ((0 == pte->GetByName("D")) && (W_ACCESS == access))
     {
         pte_val |= PTE_D;
+        fault = tlb_->UpdatePTE(vfn, pte_val);
         if ((fault = system_->dwrite(system_->handle, cpu_, pte_addr, buffer, PTESIZE)))
             return fault;
     }
 
-    fault = tlb_->UpdatePTE(vfn, pte_val);
     return fault;
 }
 

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -254,7 +254,7 @@ int32_t RISCV64MMU::CheckProtection(const PTE &pte, MM_ACCESS access)
     return etiss::RETURNCODE::NOERROR;
 }
 
-int32_t RISCV64MMU::UpdatePTEFlags(PTE *pte, etiss::mm::MM_ACCESS access)
+int32_t RISCV64MMU::UpdatePTEFlags(const uint64_t vfn, PTE *pte, etiss::mm::MM_ACCESS access)
 {
     uint64_t pte_val = pte->Get();
     uint64_t pte_addr = pte->GetAddr();
@@ -264,7 +264,6 @@ int32_t RISCV64MMU::UpdatePTEFlags(PTE *pte, etiss::mm::MM_ACCESS access)
     if (0 == pte->GetByName("A"))
     {
         pte_val |= PTE_A;
-        pte->Update(pte_val);
         if ((fault = system_->dwrite(system_->handle, cpu_, pte_addr, buffer, PTESIZE)))
             return fault;
     }
@@ -272,11 +271,11 @@ int32_t RISCV64MMU::UpdatePTEFlags(PTE *pte, etiss::mm::MM_ACCESS access)
     if ((0 == pte->GetByName("D")) && (W_ACCESS == access))
     {
         pte_val |= PTE_D;
-        pte->Update(pte_val);
         if ((fault = system_->dwrite(system_->handle, cpu_, pte_addr, buffer, PTESIZE)))
             return fault;
     }
 
+    fault = tlb_->UpdatePTE(vfn, pte_val);
     return fault;
 }
 

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -89,9 +89,9 @@ void RISCV64MMU::SignalMMU(uint64_t control_reg_val_)
     }
     if (control_reg_val_ != mmu_control_reg_val_)
     {
-        tlb_->Flush();
-        tlb_entry_map_.clear();
-        etiss::log(etiss::VERBOSE, GetName() + " : TLB flushed due to page directory update.");
+        // tlb_->Flush();
+        // tlb_entry_map_.clear();
+        // etiss::log(etiss::VERBOSE, GetName() + " : TLB flushed due to page directory update.");
         mmu_control_reg_val_ = control_reg_val_;
         if (pid_enabled_)
             UpdatePid(GetPid(control_reg_val_));

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -257,7 +257,7 @@ int32_t RISCV64MMU::CheckProtection(const PTE &pte, MM_ACCESS access)
 int32_t RISCV64MMU::UpdatePTEFlags(PTE *pte, etiss::mm::MM_ACCESS access)
 {
     uint64_t pte_val = pte->Get();
-    uint64_t pte_addr = pte->Get();
+    uint64_t pte_addr = pte->GetAddr();
     unsigned char *buffer = (unsigned char *)(&pte_val);
     int32_t fault = etiss::RETURNCODE::NOERROR;
 

--- a/ArchImpl/RISCV64/RISCV64MMU.cpp
+++ b/ArchImpl/RISCV64/RISCV64MMU.cpp
@@ -254,25 +254,25 @@ int32_t RISCV64MMU::CheckProtection(const PTE &pte, MM_ACCESS access)
     return etiss::RETURNCODE::NOERROR;
 }
 
-int32_t RISCV64MMU::UpdatePTEFlags(PTE &pte, etiss::mm::MM_ACCESS access)
+int32_t RISCV64MMU::UpdatePTEFlags(PTE *pte, etiss::mm::MM_ACCESS access)
 {
-    uint64_t pte_val = pte.Get();
-    uint64_t pte_addr = pte.GetAddr();
+    uint64_t pte_val = pte->Get();
+    uint64_t pte_addr = pte->Get();
     unsigned char *buffer = (unsigned char *)(&pte_val);
     int32_t fault = etiss::RETURNCODE::NOERROR;
 
-    if (0 == pte.GetByName("A"))
+    if (0 == pte->GetByName("A"))
     {
         pte_val |= PTE_A;
-        pte.Update(pte_val);
+        pte->Update(pte_val);
         if ((fault = system_->dwrite(system_->handle, cpu_, pte_addr, buffer, PTESIZE)))
             return fault;
     }
 
-    if ((0 == pte.GetByName("D")) && (W_ACCESS == access))
+    if ((0 == pte->GetByName("D")) && (W_ACCESS == access))
     {
         pte_val |= PTE_D;
-        pte.Update(pte_val);
+        pte->Update(pte_val);
         if ((fault = system_->dwrite(system_->handle, cpu_, pte_addr, buffer, PTESIZE)))
             return fault;
     }

--- a/ArchImpl/RISCV64/RISCV64MMU.h
+++ b/ArchImpl/RISCV64/RISCV64MMU.h
@@ -68,7 +68,7 @@ class RISCV64MMU : public etiss::mm::MMU
 
     int32_t CheckProtection(const PTE &pte, etiss::mm::MM_ACCESS access);
 
-    int32_t UpdatePTEFlags(PTE *pte, etiss::mm::MM_ACCESS access);
+    int32_t UpdatePTEFlags(const uint64_t vfn, PTE *pte, etiss::mm::MM_ACCESS access);
 
     bool CheckPrivilegedMode() { return (((RISCV64 *)cpu_)->CSR[3088] == PRV_M) ? false : true; }
 

--- a/ArchImpl/RISCV64/RISCV64MMU.h
+++ b/ArchImpl/RISCV64/RISCV64MMU.h
@@ -68,7 +68,7 @@ class RISCV64MMU : public etiss::mm::MMU
 
     int32_t CheckProtection(const PTE &pte, etiss::mm::MM_ACCESS access);
 
-    int32_t UpdatePTEFlags(PTE &pte, etiss::mm::MM_ACCESS access);
+    int32_t UpdatePTEFlags(PTE *pte, etiss::mm::MM_ACCESS access);
 
     bool CheckPrivilegedMode() { return (((RISCV64 *)cpu_)->CSR[3088] == PRV_M) ? false : true; }
 

--- a/include/etiss/mm/MMU.h
+++ b/include/etiss/mm/MMU.h
@@ -154,7 +154,7 @@ class MMU
 
     bool IsTLBFull() const { return tlb_->IsFull(); }
 
-    PTE EvictTLBEntry(const uint64_t vfn) { return tlb_->EvictPTE(vfn); }
+    void EvictTLBEntry(const uint64_t vma);
 
     bool HasPageTableWalker() { return hw_page_table_walker_; }
 

--- a/include/etiss/mm/MMU.h
+++ b/include/etiss/mm/MMU.h
@@ -150,7 +150,7 @@ class MMU
      * @brief Reserved for some MMU that might update PTE when translating
      *
      */
-    virtual int32_t UpdatePTEFlags(PTE &, MM_ACCESS) = 0;
+    virtual int32_t UpdatePTEFlags(PTE *, MM_ACCESS) = 0;
 
     bool IsTLBFull() const { return tlb_->IsFull(); }
 

--- a/include/etiss/mm/MMU.h
+++ b/include/etiss/mm/MMU.h
@@ -150,7 +150,7 @@ class MMU
      * @brief Reserved for some MMU that might update PTE when translating
      *
      */
-    virtual int32_t UpdatePTEFlags(PTE *, MM_ACCESS) = 0;
+    virtual int32_t UpdatePTEFlags(uint64_t, PTE *, MM_ACCESS) = 0;
 
     bool IsTLBFull() const { return tlb_->IsFull(); }
 

--- a/include/etiss/mm/MMU.h
+++ b/include/etiss/mm/MMU.h
@@ -176,6 +176,8 @@ class MMU
 
     std::shared_ptr<etiss::mm::TLB<0>> GetTLB() { return tlb_; }
 
+    std::map<uint64_t, PTE *> GetTLBEntryMap() { return tlb_entry_map_; }
+
     /**
      * @brief Checks if memory access is overlapping page-boundary.
      *    This is architecture specific and should be implemented by architecture.

--- a/src/mm/MMU.cpp
+++ b/src/mm/MMU.cpp
@@ -140,7 +140,7 @@ int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS ac
     uint64_t offset_mask = (1 << (page_offset_msb_pos + 1)) - 1;
     *pma_buf = (pte_buf.GetPPN() << (page_offset_msb_pos + 1)) | (vma & offset_mask);
 
-    if ((fault = UpdatePTEFlags(pte_buf, access)))
+    if ((fault = UpdatePTEFlags(&pte_buf, access)))
         return fault;
 
     // Check whether vma is trying to write the data cached in TLB, if so

--- a/src/mm/MMU.cpp
+++ b/src/mm/MMU.cpp
@@ -269,4 +269,11 @@ extern "C"
         core->getMMU()->GetTLB()->Flush();
         return etiss::RETURNCODE::RELOADBLOCKS;
     }
+
+    int32_t ETISS_TLB_EVICT_VMA(ETISS_CPU *cpu, ETISS_System * const system, void * const * const plugin_pointers, etiss_uint64 vma_)
+    {
+        CPUCore *core = (CPUCore *)cpu->_etiss_private_handle_;
+        core->getMMU()->GetTLB()->EvictPTE(vma_);
+        return etiss::RETURNCODE::RELOADBLOCKS; // TODO: reload only blocks containing the given VMA
+    }
 }

--- a/src/mm/MMU.cpp
+++ b/src/mm/MMU.cpp
@@ -140,7 +140,7 @@ int32_t MMU::Translate(const uint64_t vma, uint64_t *const pma_buf, MM_ACCESS ac
     uint64_t offset_mask = (1 << (page_offset_msb_pos + 1)) - 1;
     *pma_buf = (pte_buf.GetPPN() << (page_offset_msb_pos + 1)) | (vma & offset_mask);
 
-    if ((fault = UpdatePTEFlags(&pte_buf, access)))
+    if ((fault = UpdatePTEFlags(vpn, &pte_buf, access)))
         return fault;
 
     // Check whether vma is trying to write the data cached in TLB, if so

--- a/src/mm/MMU.cpp
+++ b/src/mm/MMU.cpp
@@ -267,6 +267,7 @@ extern "C"
     {
         CPUCore *core = (CPUCore *)cpu->_etiss_private_handle_;
         core->getMMU()->GetTLB()->Flush();
+        core->getMMU()->GetTLBEntryMap().clear();
         return etiss::RETURNCODE::RELOADBLOCKS;
     }
 


### PR DESCRIPTION
This reworks the way that PTEs get updated, when their linked page is accessed or written to.
Previously this was done only when a PTE was loaded into the TLB by a Page-Table-Walk.
Now PTEs that are already in the TLB can be updated as well, ensuring that all flags are set correctly.

This rework also includes an updated SFENCE.VMA, which can now evict single addresses from the TLB.
Reloading blocks with that address is not yet implemented.